### PR TITLE
Add Linux support for basic config

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ sequenceDiagram
   On-Prem->>Stardog: Successful user/pass authentication
   Stardog->>On-Prem: Stardog issued JWT returned
   Note over Stardog,On-Prem: On-Prem saves Stardog JWT in a session for later use.
-  On-Prem->>Stardog: Stardog API requests with Stardog JWT 
+  On-Prem->>Stardog: Stardog API requests with Stardog JWT
 ```
 
 ```mermaid
@@ -48,13 +48,13 @@ sequenceDiagram
 
 1. Login in to the Docker registry:
 
-```
+```bash
 docker login stardog-stardog-apps.jfrog.io
 ```
 
 2. Pull the latest image:
 
-```
+```bash
 docker pull stardog-stardog-apps.jfrog.io/cloud-login:onprem-current
 ```
 
@@ -65,16 +65,24 @@ docker pull stardog-stardog-apps.jfrog.io/cloud-login:onprem-current
 
 4. Create and run the container.
 
-   ```
+   ```bash
    docker run \
-     --env-file .env \
-     -p 8080:8080 \
-     --rm \
-     --name stardog-apps \
-     stardog-stardog-apps.jfrog.io/cloud-login:onprem-current
+       --env-file .env \
+       -p 8080:8080 \
+       --rm \
+       --name stardog-apps \
+       stardog-stardog-apps.jfrog.io/cloud-login:onprem-current
+
+   docker run -d \
+       --name stardog-onprem \
+       --env-file .env \
+       -p 0.0.0.0:8080:8080 \
+       --rm \
+       --add-host host.docker.internal:host-gateway \
+       stardog-stardog-apps.jfrog.io/cloud-login:onprem-current
    ```
 
-   - On-Prem will always be served at port `8080` from the container. Map this port as needed.
+   On-Prem will always be served at port `8080` from the container. Map this port as needed.
 
 ## Getting Help
 

--- a/basic/README.md
+++ b/basic/README.md
@@ -33,7 +33,7 @@ The way this configuration works is a user provides their Stardog username and p
 
 1. Execute the following command from this directory to bring up the On-Prem service.
 
-    ```
+    ```bash
     docker-compose up -d
     ```
 

--- a/basic/docker-compose.yml
+++ b/basic/docker-compose.yml
@@ -8,3 +8,6 @@ services:
       - 8080:8080
     env_file:
       - .env
+    extra_hosts:
+      - host.docker.internal:host-gateway
+    container_name: stardog-apps


### PR DESCRIPTION
Docker networking on Linux has different defaults than Docker Desktop on Mac/Windows.

Simply adding the `--add-host` parameter for `docker run` or the equivalent `extra_hosts` parameter for `docker-compose`

Additionally add code type hints for GitHub-flavored Markdown; remove trailing spaces 